### PR TITLE
Update Bundler.js

### DIFF
--- a/lib/Bundler.js
+++ b/lib/Bundler.js
@@ -48,7 +48,7 @@ export class Bundler {
   async runBundler() {
     const { logger } = this;
     logger.info('Bundling API Console...');
-    let command = './node_modules/.bin/rollup';
+    let command = '.\\node_modules\\.bin\\rollup';
     if (process.platform === 'win32') {
       command += '.cmd';
     }


### PR DESCRIPTION
on windows, command prompt must have backslashes to run a cmd file at a relative path